### PR TITLE
Add two tests for custom HTML classes (one is disabled)

### DIFF
--- a/docs/source/ref/forms.rst
+++ b/docs/source/ref/forms.rst
@@ -4,9 +4,17 @@ Forms
 
 .. py:module:: osm_field.forms
 
-OSMWidget
-=========
+OSMBoundField
+=============
 
-.. autoclass:: OSMWidget
+.. autoclass:: OSMBoundField
+    :members:
+    :show-inheritance:
+
+
+OSMFormField
+============
+
+.. autoclass:: OSMFormField
     :members:
     :show-inheritance:

--- a/docs/source/ref/index.rst
+++ b/docs/source/ref/index.rst
@@ -8,3 +8,4 @@ References
    fields
    forms
    validators
+   widgets

--- a/docs/source/ref/widgets.rst
+++ b/docs/source/ref/widgets.rst
@@ -1,0 +1,12 @@
+=======
+Widgets
+=======
+
+.. py:module:: osm_field.widgets
+
+OSMWidget
+=========
+
+.. autoclass:: OSMWidget
+    :members:
+    :show-inheritance:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -60,6 +60,55 @@ Form Layer
             model = MyModel
 
 
+Formset Layer
+=============
+
+To use OSMField with formsets with Django < 1.9, you must mixin the
+:class:`~forms.OSMFormMixin` to your child form class:
+
+``models.py``:
+
+.. code-block:: python
+
+    from django.db import models
+
+    from osm_field.fields import LatitudeField, LongitudeField, OSMField
+
+
+    class ParentModel(models.Model):
+        name = models.CharField(max_length=31)
+
+
+    class ChildModel(models.Model):
+        parent = models.ForeignKey(ParentModel, related_name='children')
+        location = OSMField()
+        location_lat = LatitudeField()
+        location_lon = LongitudeField()
+
+``forms.py``:
+
+.. code-block:: python
+
+    from django import forms
+
+    from osm_field.forms import OSMFormMixin
+
+    from .models import ChildModel, ParentModel
+
+
+    class ChildModelInlineForm(OSMFormMixin, forms.ModelForm):
+        class Meta:
+            fields = ('location', 'location_lat', 'location_lon', )
+            model = ChildModel
+
+    ChildModelFormset = forms.models.inlineformset_factory(
+        ParentModel, ChildModel, form=ChildModelInlineForm
+    )
+
+Note that you ONLY need to do this for Django < 1.9, but this will still work
+without modification (but is unnecessary) for Django >= 1.9.
+
+
 View Layer
 ==========
 

--- a/osm_field/fields.py
+++ b/osm_field/fields.py
@@ -200,15 +200,18 @@ class OSMField(TextField):
         :returns: A :class:`~osm_field.forms.OSMFormField` with a
             :class:`~osm_field.widgets.OSMWidget`.
         """
-        widget = OSMWidget(
-            lat_field=self.latitude_field_name,
-            lon_field=self.longitude_field_name,
-        )
-        kwargs.update({
+        widget_kwargs = {
+            'lat_field': self.latitude_field_name,
+            'lon_field': self.longitude_field_name,
+        }
+
+        defaults = {
             'form_class': OSMFormField,
-            'widget': widget,
-        })
-        return super(OSMField, self).formfield(**kwargs)
+            'widget': OSMWidget(**widget_kwargs),
+        }
+        defaults.update(kwargs)
+
+        return super(OSMField, self).formfield(**defaults)
 
     @property
     def latitude_field_name(self):

--- a/osm_field/fields.py
+++ b/osm_field/fields.py
@@ -5,8 +5,9 @@ from django.core import checks
 from django.db.models.fields import FieldDoesNotExist, FloatField, TextField
 from django.utils.encoding import force_text, python_2_unicode_compatible
 
-from .forms import OSMWidget
+from .forms import OSMFormField
 from .validators import validate_latitude, validate_longitude
+from .widgets import OSMWidget
 
 
 @python_2_unicode_compatible
@@ -196,12 +197,15 @@ class OSMField(TextField):
 
     def formfield(self, **kwargs):
         """
-        :returns: A :class:`~django.forms.CharField` with a
-            :class:`~osm_field.forms.OSMWidget`.
+        :returns: A :class:`~osm_field.forms.OSMFormField` with a
+            :class:`~osm_field.widgets.OSMWidget`.
         """
-        widget = OSMWidget(lat_field=self.latitude_field_name,
-            lon_field=self.longitude_field_name)
+        widget = OSMWidget(
+            lat_field=self.latitude_field_name,
+            lon_field=self.longitude_field_name,
+        )
         kwargs.update({
+            'form_class': OSMFormField,
             'widget': widget,
         })
         return super(OSMField, self).formfield(**kwargs)

--- a/osm_field/forms.py
+++ b/osm_field/forms.py
@@ -1,77 +1,52 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+import django
 
-import six
-from django.conf import settings
-from django.forms.widgets import Media, TextInput
+# For reverse compatibility
+from .widgets import OSMWidget  # flake8: noqa
 
 try:
-    from django.utils.html import format_html
+    from django.forms import BoundField, CharField, FloatField
 except ImportError:
-    from django.utils.html import conditional_escape, mark_safe
-
-    def format_html(format_string, *args, **kwargs):
-        """
-        Similar to str.format, but passes all arguments through conditional_escape,
-        and calls 'mark_safe' on the result. This function should be used instead
-        of str.format or % interpolation to build up small HTML fragments.
-        """
-        args_safe = map(conditional_escape, args)
-        kwargs_safe = dict((k, conditional_escape(v)) for (k, v) in six.iteritems(kwargs))
-        return mark_safe(format_string.format(*args_safe, **kwargs_safe))
+    from django.forms import CharField, FloatField
+    from django.forms.forms import BoundField
 
 
-def _get_js(debug=False):
-    base = ['js/vendor/leaflet.js']
-    if debug:
-        base.extend(['js/osm_field.js'])
-    else:
-        base.extend(['js/osm_field.min.js'])
-    return base
-
-
-def _get_css(debug=False):
-    base = ['css/vendor/leaflet.css']
-    if debug:
-        base.extend(['css/osm_field.css'])
-    else:
-        base.extend(['css/osm_field.min.css'])
-    return base
-
-
-class OSMWidget(TextInput):
+class PrefixedBoundField(BoundField):
     """
-    Adds a OpenStreetMap Leaflet dropdown map to the front-end once the user
-    focuses the form field. See :ref:`the usage chapter <usage-template-layer>`
-    on how to integrate the CSS and JavaScript code.
+    A bound field that passes the form's prefix into the widget's attrs
     """
-
-    @property
-    def media(self):
-        return Media(
-            css={'screen': _get_css(settings.DEBUG)},
-            js=_get_js(settings.DEBUG)
-        )
-
-    def __init__(self, lat_field, lon_field, attrs=None):
+    def as_widget(self, widget=None, attrs=None, only_initial=False):
         attrs = {} if attrs is None else attrs.copy()
-        attrs.update({
-            'data-lat-field': lat_field,
-            'data-lon-field': lon_field,
-        })
-        if 'class' in attrs:
-            attrs['class'] += ' osmfield'
-        else:
-            attrs['class'] = 'osmfield'
-        super(OSMWidget, self).__init__(attrs=attrs)
+        if self.form.prefix:
+            attrs.update({
+                'prefix': self.form.prefix,
+            })
+        return super(PrefixedBoundField, self).as_widget(widget, attrs, only_initial)
 
-    def render(self, name, value, attrs=None):
-        ret = super(OSMWidget, self).render(name, value, attrs=attrs)
-        id_ = attrs['id']
-        ret += self.render_osmfield(id_)
-        return ret
 
-    def render_osmfield(self, id_):
-        # we need {{ and }} because of .format() working with {}
-        return format_html('<script type="application/javascript">$(function()'
-                           '{{$("#{0}").osmfield();}});</script>', id_)
+class PrefixedFormFieldMixin(object):
+    """
+    A form field that binds to a custom bound field class, so we can pass the
+    form's prefix into the widget's attrs
+    """
+    def get_bound_field(self, form, field_name):
+        """
+        For Django 1.9+
+
+        Return a BoundField instance that will be used when accessing the form
+        field in a template.
+        """
+        return PrefixedBoundField(form, self, field_name)
+
+
+class OSMFormField(PrefixedFormFieldMixin, CharField):
+    pass
+
+
+class OSMFormMixin(object):
+    def __init__(self, *args, **kwargs):
+        super(OSMFormMixin, self).__init__(*args, **kwargs)
+        if django.VERSION < (1, 9):
+            for k in self.fields:
+                f = self.fields[k]
+                if issubclass(f.__class__, OSMFormField):
+                    f.widget.attrs['prefix'] = self.prefix

--- a/osm_field/widgets.py
+++ b/osm_field/widgets.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import six
+
+from django.conf import settings
+from django.forms.widgets import Media, TextInput
+
+try:
+    from django.utils.html import format_html
+except ImportError:
+    from django.utils.html import conditional_escape, mark_safe
+
+    def format_html(format_string, *args, **kwargs):
+        """
+        Similar to str.format, but passes all arguments through conditional_escape,
+        and calls 'mark_safe' on the result. This function should be used instead
+        of str.format or % interpolation to build up small HTML fragments.
+        """
+        args_safe = map(conditional_escape, args)
+        kwargs_safe = dict((k, conditional_escape(v)) for (k, v) in six.iteritems(kwargs))
+        return mark_safe(format_string.format(*args_safe, **kwargs_safe))
+
+
+def _get_js(debug=False):
+    base = ['js/vendor/leaflet.js']
+    if debug:
+        base.extend(['js/osm_field.js'])
+    else:
+        base.extend(['js/osm_field.min.js'])
+    return base
+
+
+def _get_css(debug=False):
+    base = ['css/vendor/leaflet.css']
+    if debug:
+        base.extend(['css/osm_field.css'])
+    else:
+        base.extend(['css/osm_field.min.css'])
+    return base
+
+
+class OSMWidget(TextInput):
+    """
+    Adds a OpenStreetMap Leaflet dropdown map to the front-end once the user
+    focuses the form field. See :ref:`the usage chapter <usage-template-layer>`
+    on how to integrate the CSS and JavaScript code.
+    """
+
+    @property
+    def media(self):
+        return Media(
+            css={'screen': _get_css(settings.DEBUG)},
+            js=_get_js(settings.DEBUG)
+        )
+
+    def __init__(self, lat_field, lon_field, attrs=None):
+        attrs = {} if attrs is None else attrs.copy()
+        attrs.update({
+            'data-lat-field': lat_field,
+            'data-lon-field': lon_field,
+        })
+        if 'class' in attrs:
+            attrs['class'] += ' osmfield'
+        else:
+            attrs['class'] = 'osmfield'
+        super(OSMWidget, self).__init__(attrs=attrs)
+
+    def render(self, name, value, attrs=None):
+        attrs = {} if attrs is None else attrs.copy()
+        # For Django < 1.9, we need to grab self.attrs instead
+        prefix = attrs.get('prefix', self.attrs.get('prefix', ''))
+        if prefix:
+            attrs.update({
+                'data-lat-field': '{}-{}'.format(prefix, attrs.get('data-lat-field', self.attrs['data-lat-field'])),
+                'data-lon-field': '{}-{}'.format(prefix, attrs.get('data-lon-field', self.attrs['data-lon-field'])),
+            })
+        ret = super(OSMWidget, self).render(name, value, attrs=attrs)
+        id_ = attrs['id']
+        ret += self.render_osmfield(id_)
+        return ret
+
+    def render_osmfield(self, id_):
+        # we need {{ and }} because of .format() working with {}
+        return format_html('<script type="application/javascript">$(function()'
+                           '{{$("#{0}").osmfield();}});</script>', id_)

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -4,6 +4,7 @@ from .models import (
     ChildModel, CustomNamingModel, DefaultNamingModel, MixedNamingModel,
     MultipleNamingModel, ParentModel,
 )
+from osm_field.forms import OSMWidget  # Should eventually be osm_field.widgets
 
 from osm_field.forms import OSMFormMixin
 
@@ -37,6 +38,28 @@ class MultipleNamingForm(forms.ModelForm):
             'custom_location', 'custom_latitude', 'custom_longitude',
         )
         model = MultipleNamingModel
+
+
+class FieldWidgetWithClassNameForm(forms.ModelForm):
+    location = forms.CharField(widget=OSMWidget('location_lat', 'location_lon', attrs={
+        'class': 'custom-class',
+    }))
+
+    class Meta:
+        fields = ('location', 'location_lat', 'location_lon', )
+        model = DefaultNamingModel
+
+
+class WidgetsWidgetWithClassNameForm(forms.ModelForm):
+
+    class Meta:
+        fields = ('location', 'location_lat', 'location_lon', )
+        model = DefaultNamingModel
+        widgets = {
+            'location': OSMWidget('location_lat', 'location_lon', attrs={
+                'class': 'custom-class',
+            }),
+        }
 
 
 class ChildModelInlineForm(OSMFormMixin, forms.ModelForm):

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -1,9 +1,11 @@
 from django import forms
 
 from .models import (
-    CustomNamingModel, DefaultNamingModel, MixedNamingModel,
-    MultipleNamingModel,
+    ChildModel, CustomNamingModel, DefaultNamingModel, MixedNamingModel,
+    MultipleNamingModel, ParentModel,
 )
+
+from osm_field.forms import OSMFormMixin
 
 
 class CustomNamingForm(forms.ModelForm):
@@ -35,3 +37,14 @@ class MultipleNamingForm(forms.ModelForm):
             'custom_location', 'custom_latitude', 'custom_longitude',
         )
         model = MultipleNamingModel
+
+
+class ChildModelInlineForm(OSMFormMixin, forms.ModelForm):
+    class Meta:
+        fields = ('location', 'location_lat', 'location_lon', )
+        model = ChildModel
+
+
+ChildModelFormset = forms.models.inlineformset_factory(
+    ParentModel, ChildModel, extra=2, form=ChildModelInlineForm,
+)

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -64,4 +64,27 @@ class Migration(migrations.Migration):
             },
             bases=(models.Model,),
         ),
+        migrations.CreateModel(
+            name='ParentModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', auto_created=True, serialize=False, primary_key=True)),
+                ('name', models.CharField(max_length=31)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='ChildModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', auto_created=True, serialize=False, primary_key=True)),
+                ('parent', models.ForeignKey(related_name='children', to='tests.ParentModel')),
+                ('location', osm_field.fields.OSMField(lat_field='location_lat', lon_field='location_lon')),
+                ('location_lat', osm_field.fields.LatitudeField(validators=[osm_field.validators.validate_latitude])),
+                ('location_lon', osm_field.fields.LongitudeField(validators=[osm_field.validators.validate_longitude])),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
     ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -30,3 +30,14 @@ class MultipleNamingModel(models.Model):
         lon_field='custom_longitude')
     custom_latitude = LatitudeField()
     custom_longitude = LongitudeField()
+
+
+class ParentModel(models.Model):
+    name = models.CharField(max_length=31)
+
+
+class ChildModel(models.Model):
+    parent = models.ForeignKey(ParentModel, related_name='children')
+    location = OSMField()
+    location_lat = LatitudeField()
+    location_lon = LongitudeField()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -14,8 +14,8 @@ from .models import (
 )
 
 from osm_field.fields import LatitudeField, Location, LongitudeField, OSMField
-from osm_field.forms import OSMWidget
 from osm_field.validators import validate_latitude, validate_longitude
+from osm_field.widgets import OSMWidget
 
 try:
     from django.core.checks import Error

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -4,8 +4,9 @@ from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
 from .forms import (
-    ChildModelFormset, CustomNamingForm, DefaultNamingForm, MixedNamingForm,
-    MultipleNamingForm,
+    ChildModelFormset, CustomNamingForm, DefaultNamingForm,
+    FieldWidgetWithClassNameForm, MixedNamingForm, MultipleNamingForm,
+    WidgetsWidgetWithClassNameForm,
 )
 
 
@@ -77,6 +78,14 @@ class TestWidget(SimpleTestCase):
             '</script>',
             html
         )
+
+    def test_field_widget_contains_class(self):
+        html = FieldWidgetWithClassNameForm().as_p()
+        self.assertIn('class="custom-class osmfield"', html)
+
+    def test_widgets_widget_contains_class(self):
+        html = WidgetsWidgetWithClassNameForm().as_p()
+        self.assertIn('class="custom-class osmfield"', html)
 
     def test_widget_prefix_in_formset(self):
         html = ChildModelFormset().as_p()

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -4,7 +4,8 @@ from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
 from .forms import (
-    CustomNamingForm, DefaultNamingForm, MixedNamingForm, MultipleNamingForm,
+    ChildModelFormset, CustomNamingForm, DefaultNamingForm, MixedNamingForm,
+    MultipleNamingForm,
 )
 
 
@@ -73,6 +74,39 @@ class TestWidget(SimpleTestCase):
         self.assertIn(
             '<script type="application/javascript">'
             '$(function(){$("#id_custom_location").osmfield();});'
+            '</script>',
+            html
+        )
+
+    def test_widget_prefix_in_formset(self):
+        html = ChildModelFormset().as_p()
+        # Check for form 0
+        self.assertIn('id="id_children-0-location"', html)
+        self.assertIn('name="children-0-location"', html)
+        self.assertIn('data-lat-field="children-0-location_lat"', html)
+        self.assertIn('data-lon-field="children-0-location_lon"', html)
+        self.assertIn('id="id_children-0-location_lat"', html)
+        self.assertIn('id="id_children-0-location_lon"', html)
+        self.assertIn('name="children-0-location_lat"', html)
+        self.assertIn('name="children-0-location_lon"', html)
+        self.assertIn(
+            '<script type="application/javascript">'
+            '$(function(){$("#id_children-0-location").osmfield();});'
+            '</script>',
+            html
+        )
+        # Check for form 1
+        self.assertIn('id="id_children-1-location"', html)
+        self.assertIn('name="children-1-location"', html)
+        self.assertIn('data-lat-field="children-1-location_lat"', html)
+        self.assertIn('data-lon-field="children-1-location_lon"', html)
+        self.assertIn('id="id_children-1-location_lat"', html)
+        self.assertIn('id="id_children-1-location_lon"', html)
+        self.assertIn('name="children-1-location_lat"', html)
+        self.assertIn('name="children-1-location_lon"', html)
+        self.assertIn(
+            '<script type="application/javascript">'
+            '$(function(){$("#id_children-1-location").osmfield();});'
             '</script>',
             html
         )


### PR DESCRIPTION
I noticed that line 62 of `forms.py` wasn't tested, so here's a test for it.

On the other hand, I noticed that this package doesn't support specifying the widgets in a `ModelForm.Meta` class like so:

```python
 class WidgetsWidgetWithClassNameForm(forms.ModelForm):

     class Meta:
         fields = ('location', 'location_lat', 'location_lon', )
         model = DefaultNamingModel
         widgets = {
             'location': OSMWidget('location_lat', 'location_lon', attrs={
                 'class': 'custom-class',
             }),
         }
```

so that test form and test is disabled.